### PR TITLE
pdsh timeouts can be set in environment variables

### DIFF
--- a/doc/pdsh.1.in
+++ b/doc/pdsh.1.in
@@ -183,10 +183,14 @@ be listed in the user\'s .rhosts file (even for root).
 .TP
 .I "-t seconds"
 Set the connect timeout. Default is @CONNECT_TIMEOUT@ seconds.
+This option may also be set via the PDSH_CONNECT_TIMEOUT environment
+variable.
 .TP
 .I "-u seconds"
 Set a limit on the amount of time a remote command is allowed to execute.
 Default is no limit. See note in LIMITATIONS if using \fI-u\fR with ssh.
+This option may also be set via the PDSH_COMMAND_TIMEOUT environment
+variable.
 .TP
 .I "-f number"
 Set the maximum number of simultaneous remote commands to \fInumber\fR.

--- a/src/pdsh/opt.c
+++ b/src/pdsh/opt.c
@@ -449,6 +449,14 @@ void opt_env(opt_t * opt)
         if (string_to_int (rhs, &opt->fanout) < 0)
             errx ("%p: Invalid environment variable FANOUT=%s\n", rhs);
 
+    if ((rhs = getenv("PDSH_CONNECT_TIMEOUT")) != NULL)
+        if (string_to_int (rhs, &opt->connect_timeout) < 0)
+            errx ("%p: Invalid environment variable PDSH_CONNECT_TIMEOUT=%s\n", rhs);
+
+    if ((rhs = getenv("PDSH_COMMAND_TIMEOUT")) != NULL)
+        if (string_to_int (rhs, &opt->command_timeout) < 0)
+            errx ("%p: Invalid environment variable PDSH_COMMAND_TIMEOUT=%s\n", rhs);
+
     if ((rhs = getenv("PDSH_RCMD_TYPE")) != NULL)
         opt->rcmd_name = Strdup(rhs);
 

--- a/tests/t0001-basic.sh
+++ b/tests/t0001-basic.sh
@@ -162,6 +162,12 @@ check_pdsh_option() {
 	pdsh -$flag$flagval -w foo -q | grep -q "$name[ 	]*$value$"
 }
 
+check_pdsh_env_variable() {
+	env_var=$1; name=$2; env_var_val=$3;
+	echo "env_var=$env_var name='$name' env_var_val=$env_var_val"
+	env $env_var=$env_var_val pdsh -w foo -q | grep -q "$name[ 	]*$env_var_val$"
+}
+
 test_expect_success '-f sets fanout' '
 	check_pdsh_option f Fanout 8
 '
@@ -180,8 +186,14 @@ test_expect_success 'too long username fails gracefully' '
 test_expect_success '-t sets connect timeout' '
 	check_pdsh_option t "Connect timeout (secs)" 33
 '
+test_expect_success 'env PDSH_CONNECT_TIMEOUT sets connect timeout' '
+	check_pdsh_env_variable PDSH_CONNECT_TIMEOUT "Connect timeout (secs)" 33
+'
 test_expect_success '-u sets command timeout' '
 	check_pdsh_option u "Command timeout (secs)" 22
+'
+test_expect_success 'env PDSH_COMMAND_TIMEOUT sets command timeout' '
+	check_pdsh_env_variable PDSH_COMMAND_TIMEOUT "Command timeout (secs)" 22
 '
 test_expect_success 'command timeout 0 by default' '
     pdsh -w foo -q | grep -q "Command timeout (secs)[ 	]*0$"


### PR DESCRIPTION
pdsh allows environment variables for various settings. However, the connect
and command timeouts only have command line options.

This change makes it so these timeouts can be specified as environment
variables. That way, if a site decides it is best, the variables can be
set to impact pdsh commands that are buried in infrastructure.

PDSH_CONNECT_TIMEOUT
and
PDSH_COMMAND_TIMEOUT

Are the environment variables.
