### PR TITLE
 Update to configure to compile torque module conftest

### DIFF
--- a/config/ac_torque.m4
+++ b/config/ac_torque.m4
@@ -33,7 +33,7 @@ AC_DEFUN([AC_TORQUE],
 
   if test "$ac_with_torque" = "yes"; then
     if pbs-config 1>/dev/null 2>&1; then
-      TORQUE_LIBS=$(pbs-config --libs)
+      TORQUE_LIBS=$(pbs-config --libs --libadd)
       TORQUE_CPPFLAGS=$(pbs-config --cflags)
       saveLIBS="$LIBS"
       LIBS="$TORQUE_LIBS $LIBS"

--- a/configure
+++ b/configure
@@ -26478,7 +26478,7 @@ echo "${ECHO_T}${ac_with_torque=no}" >&6
 
   if test "$ac_with_torque" = "yes"; then
     if pbs-config 1>/dev/null 2>&1; then
-      TORQUE_LIBS=$(pbs-config --libs)
+      TORQUE_LIBS=$(pbs-config --libs --libadd)
       TORQUE_CPPFLAGS=$(pbs-config --cflags)
       saveLIBS="$LIBS"
       LIBS="$TORQUE_LIBS $LIBS"


### PR DESCRIPTION
Torque libraries are not always in a standard location. Asking torque with pbs-config --libadd returns -L/correct/path which I have simply added to $LIBS in configure. This is saved and used in the torque conftest. configure still requires --libdir=/correct/path for the make.